### PR TITLE
ci: Remove || true against 127

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -19,4 +19,4 @@ jobs:
       - name: asdf_plugin_test
         uses: asdf-vm/actions/plugin-test@v3
         with:
-          command: tofu --version || true
+          command: tofu version

--- a/contributing.md
+++ b/contributing.md
@@ -5,7 +5,6 @@ Testing Locally:
 ```shell
 asdf plugin test <plugin-name> <plugin-url> [--asdf-tool-version <version>] [--asdf-plugin-gitref <git-ref>] [test-command*]
 
-# TODO: adapt this
 asdf plugin test opentofu https://github.com/virtualroot/asdf-opentofu.git "tofu version"
 ```
 


### PR DESCRIPTION
`asdf plugin test opentofu https://github.com/virtualroot/asdf-opentofu.git "tofu version"` is :green_circle: 

Therefore I'm removing the hackish `|| true`.