### PR TITLE
fix: Change certificate-identity URL

### DIFF
--- a/lib/utils.bash
+++ b/lib/utils.bash
@@ -117,7 +117,7 @@ verify() {
 	local -r checksum_file="${TOOL_BIN_NAME}_${version}_SHA256SUMS"
 	local -r signature_file="${checksum_file}.sig"
 	local -r cert_file="${checksum_file}.pem"
-	local -r cert_identity="https://github.com/opentofu/opentofu/.github/workflows/release.yml@refs/tags/v${version}"
+	local -r cert_identity="https://github.com/opentofu/opentofu/.github/workflows/release.yml@refs/head/main"
 	local -r cert_oidc_issuer="https://token.actions.githubusercontent.com"
 
 	baseURL="$GH_REPO/releases/download/v${version}"


### PR DESCRIPTION
From beta5 onwards, releases are triggered from the main branch.

Context https://github.com/opentofu/opentofu/issues/1037

Fix #17