### PR TITLE
fix: Change certificate-identity URL

### DIFF
--- a/lib/utils.bash
+++ b/lib/utils.bash
@@ -117,7 +117,7 @@ verify() {
 	local -r checksum_file="${TOOL_BIN_NAME}_${version}_SHA256SUMS"
 	local -r signature_file="${checksum_file}.sig"
 	local -r cert_file="${checksum_file}.pem"
-	local -r cert_identity="https://github.com/opentofu/opentofu/.github/workflows/release.yml@refs/heads/main"
+	local -r cert_identity="https://github.com/opentofu/opentofu/.github/workflows/release.yml@refs/heads/v${version%.*}"
 	local -r cert_oidc_issuer="https://token.actions.githubusercontent.com"
 
 	baseURL="$GH_REPO/releases/download/v${version}"


### PR DESCRIPTION
https://github.com/opentofu/opentofu/releases/tag/v1.6.0-rc1

> Importantly, we've changed the identity of the cosign signatures
> to the new version branch, which means that when verifying
> binaries from GitHub releases, you'll need to pass
> --certificate-identity https://github.com/opentofu/opentofu/.github/workflows/release.yml@refs/heads/v1.6.