### PR TITLE
feat: support for legacy_version_file mode

### DIFF
--- a/bin/list-legacy-filenames
+++ b/bin/list-legacy-filenames
@@ -1,0 +1,6 @@
+#!/usr/bin/env bash
+
+# SPDX-License-Identifier: MIT
+# SPDX-FileCopyrightText: Copyright (c) 2017 Jack Henry & Associates
+
+echo ".opentofu-version ${ASDF_OPENTOFU_VERSION_FILE:-main.tofu}"

--- a/bin/parse-legacy-file
+++ b/bin/parse-legacy-file
@@ -1,0 +1,65 @@
+#!/usr/bin/env bash
+
+# SPDX-License-Identifier: MIT
+# SPDX-FileCopyrightText: Copyright (c) 2017 Jack Henry & Associates
+
+set -Eeuo pipefail
+
+[[ -n ${DEBUG-} ]] && set -x
+
+# override is exposed for testing purposes.
+THIS_PLUGIN="${ASDF_OPENTOFU_THIS_PLUGIN:-"$(basename "$(dirname "$(dirname "$0")")")"}"
+SUPPORTED_PLUGINS=(opentofu)
+
+is_strict_equality_version_constraint() {
+  local -r version_constraint="$1"
+  grep --quiet -E '^=?[[:digit:]]+\.[[:digit:]]+.[[:digit:]]+' <<<"${version_constraint}"
+}
+
+read_version_from_main_tofu() {
+  local -r version_file="$1"
+  local -r required_version_constraint="$(grep --no-filename \
+    --recursive \
+    --fixed-strings \
+    required_version \
+    "${version_file}" |
+    sed -E 's/[[:space:]]*required_version[[:space:]]*=//' |
+    tr -d '" ')"
+
+  [[ -z ${required_version_constraint} ]] && return 0
+
+  if is_strict_equality_version_constraint "${required_version_constraint}"; then
+    tr -d '=' <<<"${required_version_constraint}"
+  else
+    cat >&2 <<EOF
+FATAL: Found legacy version file '${ASDF_OPENTOFU_VERSION_FILE:-main.tofu}' with unsupported required
+version constraint expression: '${required_version_constraint}'. This
+plugin only supports strict equality.
+
+EOF
+    exit 1
+  fi
+}
+
+get_legacy_version() {
+  local -r version_file="$1"
+  local this_plugin_supported=false
+
+  # check if current plugin is supported
+  for plugin in "${SUPPORTED_PLUGINS[@]}"; do
+    if [[ ${plugin} == "${THIS_PLUGIN}" ]]; then
+      this_plugin_supported=true
+      break
+    fi
+  done
+
+  [[ ${this_plugin_supported} == false ]] && return 0
+
+  if [[ ${version_file} == *".${THIS_PLUGIN}-version" && -r ${version_file} ]]; then
+    cat "${version_file}"
+  elif [[ ${version_file} =~ ${ASDF_OPENTOFU_VERSION_FILE:-main.tofu} && -r ${version_file} ]]; then
+    read_version_from_main_tofu "${version_file}"
+  fi
+}
+
+get_legacy_version "$1"

--- a/tests/parse-legacy-file.bats
+++ b/tests/parse-legacy-file.bats
@@ -1,0 +1,164 @@
+#!/usr/bin/env bats
+
+# SPDX-License-Identifier: MIT
+# SPDX-FileCopyrightText: Copyright (c) 2017 Jack Henry & Associates
+
+setup() {
+  ASDF_OPENTOFU="$(dirname "$BATS_TEST_DIRNAME")"
+  PARSE_LEGACY_FILE="${ASDF_OPENTOFU}/bin/parse-legacy-file"
+}
+
+@test "supports legacy opentofu version 'required_version' with strict equality" {
+  local -r expected_opentofu_version=0.13.7
+  local -r tmpdir="$(mktemp -d)"
+  local -r version_file="${tmpdir}/main.tofu"
+  cat <<EOF >"${version_file}"
+terraform {
+  required_version = "= ${expected_opentofu_version}"
+}
+EOF
+
+  local -r actual_opentofu_version="$(ASDF_OPENTOFU_THIS_PLUGIN=opentofu "${PARSE_LEGACY_FILE}" "${version_file}")"
+
+  [[ ${actual_opentofu_version} == "${expected_opentofu_version}" ]]
+}
+
+@test "supports alternate file for opentofu version constraints" {
+  local -r expected_opentofu_version=0.13.7
+  local -r tmpdir="$(mktemp -d)"
+  local -r version_file="${tmpdir}/versions.tofu"
+  cat <<EOF >"${version_file}"
+terraform {
+  required_version = "= ${expected_opentofu_version}"
+}
+EOF
+
+  local -r actual_opentofu_version="$(ASDF_OPENTOFU_VERSION_FILE=versions.tofu ASDF_OPENTOFU_THIS_PLUGIN=opentofu "${PARSE_LEGACY_FILE}" "${version_file}")"
+
+  [[ ${actual_opentofu_version} == "${expected_opentofu_version}" ]]
+}
+
+@test "supports legacy opentofu version 'required_version' with strict equality, no equals literal" {
+  local -r expected_opentofu_version=0.13.7
+  local -r tmpdir="$(mktemp -d)"
+  local -r version_file="${tmpdir}/main.tofu"
+  cat <<EOF >"${version_file}"
+terraform {
+  required_version = "${expected_opentofu_version}"
+}
+EOF
+
+  local -r actual_opentofu_version="$(ASDF_OPENTOFU_THIS_PLUGIN=opentofu "${PARSE_LEGACY_FILE}" "${version_file}")"
+
+  [[ ${actual_opentofu_version} == "${expected_opentofu_version}" ]]
+}
+
+@test "supports legacy file .opentofu-version" {
+  local -r expected_opentofu_version=0.13.7
+  local -r tmpdir="$(mktemp -d)"
+  local -r version_file="${tmpdir}/.opentofu-version"
+
+  echo "${expected_opentofu_version}" >"${tmpdir}/.opentofu-version"
+
+  local -r actual_opentofu_version="$(ASDF_OPENTOFU_THIS_PLUGIN=opentofu "${PARSE_LEGACY_FILE}" "${version_file}")"
+
+  [[ ${actual_opentofu_version} == "${expected_opentofu_version}" ]]
+}
+
+@test "does not support 'not equal' version constraint expressions" {
+  local -r tmpdir="$(mktemp -d)"
+  local -r version_file="${tmpdir}/main.tofu"
+  cat <<EOF >"${version_file}"
+terraform {
+  required_version = "!= 0.13.7"
+}
+EOF
+
+  local -r actual_opentofu_version="$(ASDF_OPENTOFU_THIS_PLUGIN=opentofu "${PARSE_LEGACY_FILE}" "${version_file}")"
+
+  [[ ${actual_opentofu_version} == "" ]]
+}
+
+@test "does not support 'greater than' version constraint expressions" {
+  local -r tmpdir="$(mktemp -d)"
+  local -r version_file="${tmpdir}/main.tofu"
+  cat <<EOF >"${version_file}"
+terraform {
+  required_version = "> 0.13.7"
+}
+EOF
+
+  local -r actual_opentofu_version="$(ASDF_OPENTOFU_THIS_PLUGIN=opentofu "${PARSE_LEGACY_FILE}" "${version_file}")"
+
+  [[ ${actual_opentofu_version} == "" ]]
+}
+
+@test "does not support 'less than' version constraint expressions" {
+  local -r tmpdir="$(mktemp -d)"
+  local -r version_file="${tmpdir}/main.tofu"
+  cat <<EOF >"${version_file}"
+terraform {
+  required_version = "< 0.13.7"
+}
+EOF
+
+  local -r actual_opentofu_version="$(ASDF_OPENTOFU_THIS_PLUGIN=opentofu "${PARSE_LEGACY_FILE}" "${version_file}")"
+
+  [[ ${actual_opentofu_version} == "" ]]
+}
+
+@test "does not support squiggly arrow version constraint expressions" {
+  local -r tmpdir="$(mktemp -d)"
+  local -r version_file="${tmpdir}/main.tofu"
+  cat <<EOF >"${version_file}"
+terraform {
+  required_version = "~> 0.13.7"
+}
+EOF
+
+  local -r actual_opentofu_version="$(ASDF_OPENTOFU_THIS_PLUGIN=opentofu "${PARSE_LEGACY_FILE}" "${version_file}")"
+
+  [[ ${actual_opentofu_version} == "" ]]
+}
+
+@test "does not support compound version constraint expressions" {
+  local -r tmpdir="$(mktemp -d)"
+  local -r version_file="${tmpdir}/main.tofu"
+  cat <<EOF >"${version_file}"
+terraform {
+  required_version = "> 0.13.0, < 0.14.0"
+}
+EOF
+
+  local -r actual_opentofu_version="$(ASDF_OPENTOFU_THIS_PLUGIN=opentofu "${PARSE_LEGACY_FILE}" "${version_file}")"
+
+  [[ ${actual_opentofu_version} == "" ]]
+}
+
+# https://github.com/asdf-community/asdf-hashicorp/pull/43#discussion_r816027246
+@test 'does not get confused by multiple legacy version files for different plugins' {
+  local -r expected_opentofu_version=0.13.7
+  local -r tmpdir="$(mktemp -d)"
+  local -r version_file="${tmpdir}/main.tofu"
+  cat <<EOF >"${version_file}"
+terraform {
+  required_version = "= ${expected_opentofu_version}"
+}
+EOF
+
+  echo 'foo' >"${tmpdir}/.opentofu-version"
+
+  local -r actual_opentofu_version="$(ASDF_OPENTOFU_THIS_PLUGIN=opentofu "${PARSE_LEGACY_FILE}" "${version_file}")"
+
+  [[ ${actual_opentofu_version} == "${expected_opentofu_version}" ]]
+}
+
+@test "does not output error if required_version is not specified" {
+  local -r tmpdir="$(mktemp -d)"
+  local -r version_file="${tmpdir}/main.tofu"
+  touch "${version_file}"
+
+  local -r actual_opentofu_version="$(ASDF_OPENTOFU_THIS_PLUGIN=opentofu "${PARSE_LEGACY_FILE}" "${version_file}" 2>&1)"
+
+  [[ ${actual_opentofu_version} == "" ]]
+}


### PR DESCRIPTION
Fixes: #32 

I added a test file (basically a modified copy of  https://github.com/asdf-community/asdf-hashicorp/blob/master/test/parse-legacy-file.bats): 

```console
opentofu $ bats tests/parse-legacy-file.bats 
parse-legacy-file.bats
 ✓ supports legacy opentofu version 'required_version' with strict equality
 ✓ supports alternate file for opentofu version constraints
 ✓ supports legacy opentofu version 'required_version' with strict equality, no equals literal
 ✓ supports legacy file .opentofu-version
 ✓ does not support 'not equal' version constraint expressions
 ✓ does not support 'greater than' version constraint expressions
 ✓ does not support 'less than' version constraint expressions
 ✓ does not support squiggly arrow version constraint expressions
 ✓ does not support compound version constraint expressions
 ✓ does not get confused by multiple legacy version files for different plugins
 ✓ does not output error if required_version is not specified

11 tests, 0 failures
```